### PR TITLE
Fix search-bar performance

### DIFF
--- a/lib/helpers/debouncer.dart
+++ b/lib/helpers/debouncer.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+// Creditos
+// https://stackoverflow.com/a/52922130/7834829
+
+class Debouncer<T> {
+
+  Debouncer({ 
+    required this.duration, 
+    this.onValue 
+  });
+
+  final Duration duration;
+
+  void Function(T value)? onValue;
+
+  T? _value;
+  Timer? _timer;
+  
+   T get value => _value!;
+
+  set value(T val) {
+    _value = val;
+    _timer?.cancel();
+    _timer = Timer(duration, () => onValue!(_value as T));
+  }  
+}

--- a/lib/provider/movies_provider.dart
+++ b/lib/provider/movies_provider.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:movies_app/helpers/debouncer.dart';
 import 'package:movies_app/models/search_response.dart';
 
 import '../models/models.dart';
@@ -14,6 +17,15 @@ class MoviesProvider extends ChangeNotifier {
   Map<int, List<Cast>> moviesCast = {};
 
   int _popularPage = 0;
+
+  final debouncer = Debouncer(
+    duration: const Duration(
+      milliseconds: 500
+    ),
+  );
+
+  final StreamController<List<Movie>> _suggestionsStreamController = new StreamController.broadcast();
+  Stream<List<Movie>> get suggestionsStream => this._suggestionsStreamController.stream;
 
   MoviesProvider() {
     getOnDisplayMovies();
@@ -65,4 +77,20 @@ class MoviesProvider extends ChangeNotifier {
     final searchResponse = SearchResponse.fromJson(response.body);
     return searchResponse.results;
   }
+
+  void getSuggestionsByQuery(String searchTerm){
+    debouncer.value='';
+    debouncer.onValue= (value) async{
+      final results = await searchMovie(value);
+      _suggestionsStreamController.add(results);
+      print('apenas se hace la consulta');
+    };
+    final timer =Timer.periodic(const Duration(milliseconds: 300), (_) {
+      debouncer.value = searchTerm;
+     });
+
+     Future.delayed(const Duration(milliseconds: 301)).then((_) => timer.cancel());
+  }
+
+
 }

--- a/lib/search/search_delegate.dart
+++ b/lib/search/search_delegate.dart
@@ -50,9 +50,10 @@ class MovieSearchDelegate extends SearchDelegate{
   }
 
   final moviesProvider = Provider.of<MoviesProvider>(context, listen: false);
+  moviesProvider.getSuggestionsByQuery(query);
    
-  return FutureBuilder(
-    future: moviesProvider.searchMovie(query),
+  return StreamBuilder(
+    stream: moviesProvider.suggestionsStream,
     builder: (_,AsyncSnapshot<List<Movie>> snapshot){
       if(!snapshot.hasData) return _emptyContainer();
       final movies =snapshot.data!;


### PR DESCRIPTION
## Fix API query overflow

## Problem
### The search-bar generates an API request every time its status is updated, generating high unnecessary traffic.

## Solution
* Added a debouncer:
### Debouncer maintains a timeout after the user stops using the keyboard to type the query in the search-bar. 
